### PR TITLE
Add basic support for fzf-lua.

### DIFF
--- a/lua/zappykasten/fzf-lua.lua
+++ b/lua/zappykasten/fzf-lua.lua
@@ -1,49 +1,53 @@
+local M = {}
 local fzf_lua_ok, fzf_lua = pcall(require, 'fzf-lua')
 
-local M = {}
+-- unpack is going to be deprecated soon
+local table_unpack = table.unpack or unpack -- 5.1 compatibility
 
 if not fzf_lua_ok or not fzf_lua.grep then
-  function M.search_notes()
-    print("fzf-lua or fzf-lua.grep could not be loaded. Please ensure fzf-lua is correctly installed and updated.")
+  function M.search_notes(_, _, _)
+    vim.notify("fzf-lua or fzf-lua.grep could not be loaded. Please ensure fzf-lua is correctly installed and updated.")
   end
+
   return M
 end
 
--- Options passed to ripgrep.
 local rg_options = {
   '--no-messages',
-  '--no-heading',       -- Don't print the initial summary
-  '--with-filename',    -- Print the filename for each match
-  '--follow',           -- Follow symbolic links
-  '--smart-case',       -- Search case-insensitively unless query contains uppercase
-  '--line-number',      -- Print the line number for each match
-  '--color=never',      -- Disable ripgrep's colors; fzf will handle colors
+  '--no-heading',    -- Don't print the initial summary
+  '--with-filename', -- Print the filename for each match
+  '--follow',        -- Follow symbolic links
+  '--smart-case',    -- Search case-insensitively unless query contains uppercase
+  '--line-number',   -- Print the line number for each match
+  '--color=never',   -- Disable ripgrep's colors; fzf will handle colors
 }
 
--- Options passed directly to the fzf command
 local fzf_options = {
-  ['--ansi'] = '',         -- Interpret ANSI color codes (though rg --color=never should prevent them)
-  ['--multi'] = '',        -- Allow selecting multiple items with Tab
+  ['--ansi'] = '',  -- Interpret ANSI color codes (though rg --color=never should prevent them)
+  ['--multi'] = '', -- Allow selecting multiple items with Tab
   ['--info'] = 'inline',
   ['--tiebreak'] = 'length,begin',
-  -- ['--preview'] = 'bat --color=always --highlight-line {2} {1}', -- Example custom preview
-  -- ['--preview-window'] = 'right:50%:wrap',
 }
 
-function M.search_notes()
+local function key_handler(selected, note_key)
+  local query = fzf_lua.get_last_query()
+  vim.call("ZK_note_handler", { query, note_key, table_unpack(selected) })
+end
+
+function M.search_notes(_, create_note_key, yank_key)
   fzf_lua.live_grep({
     prompt = 'Search> ',
     grep_cmd = "rg",
     grep_opts = table.concat(rg_options, " "),
     search_paths = vim.g.zk_search_paths,
-
-    -- TODO: respect zk_include_hidden and zk_use_ignore_files
-    --"--glob='!*.git'",    -- Example: Ignore .git directory (rg often does this by default)
-    --"--glob='*'",         -- Ensure all files are considered (respecting .gitignore etc.)
-
     actions = {
       ['default'] = require('fzf-lua.actions').file_jump,
-      -- ['ctrl-n'] = function(selected) ...,
+      [create_note_key] = function(selected, _)
+        key_handler(selected, create_note_key)
+      end,
+      [yank_key] = function(selected, _)
+        key_handler(selected, yank_key)
+      end
     },
 
     fzf_opts = fzf_options,

--- a/lua/zappykasten/fzf-lua.lua
+++ b/lua/zappykasten/fzf-lua.lua
@@ -1,0 +1,53 @@
+local fzf_lua_ok, fzf_lua = pcall(require, 'fzf-lua')
+
+local M = {}
+
+if not fzf_lua_ok or not fzf_lua.grep then
+  function M.search_notes()
+    print("fzf-lua or fzf-lua.grep could not be loaded. Please ensure fzf-lua is correctly installed and updated.")
+  end
+  return M
+end
+
+-- Options passed to ripgrep.
+local rg_options = {
+  '--no-messages',
+  '--no-heading',       -- Don't print the initial summary
+  '--with-filename',    -- Print the filename for each match
+  '--follow',           -- Follow symbolic links
+  '--smart-case',       -- Search case-insensitively unless query contains uppercase
+  '--line-number',      -- Print the line number for each match
+  '--color=never',      -- Disable ripgrep's colors; fzf will handle colors
+}
+
+-- Options passed directly to the fzf command
+local fzf_options = {
+  ['--ansi'] = '',         -- Interpret ANSI color codes (though rg --color=never should prevent them)
+  ['--multi'] = '',        -- Allow selecting multiple items with Tab
+  ['--info'] = 'inline',
+  ['--tiebreak'] = 'length,begin',
+  -- ['--preview'] = 'bat --color=always --highlight-line {2} {1}', -- Example custom preview
+  -- ['--preview-window'] = 'right:50%:wrap',
+}
+
+function M.search_notes()
+  fzf_lua.live_grep({
+    prompt = 'Search> ',
+    grep_cmd = "rg",
+    grep_opts = table.concat(rg_options, " "),
+    search_paths = vim.g.zk_search_paths,
+
+    -- TODO: respect zk_include_hidden and zk_use_ignore_files
+    --"--glob='!*.git'",    -- Example: Ignore .git directory (rg often does this by default)
+    --"--glob='*'",         -- Ensure all files are considered (respecting .gitignore etc.)
+
+    actions = {
+      ['default'] = require('fzf-lua.actions').file_jump,
+      -- ['ctrl-n'] = function(selected) ...,
+    },
+
+    fzf_opts = fzf_options,
+  })
+end
+
+return M

--- a/lua/zappykasten/fzf-lua.lua
+++ b/lua/zappykasten/fzf-lua.lua
@@ -4,23 +4,13 @@ local fzf_lua_ok, fzf_lua = pcall(require, 'fzf-lua')
 -- unpack is going to be deprecated soon
 local table_unpack = table.unpack or unpack -- 5.1 compatibility
 
-if not fzf_lua_ok or not fzf_lua.grep then
+if not fzf_lua_ok or not fzf_lua.live_grep then
   function M.search_notes(_, _, _)
-    vim.notify("fzf-lua or fzf-lua.grep could not be loaded. Please ensure fzf-lua is correctly installed and updated.")
+    vim.notify("fzf-lua or fzf-lua.live_grep could not be loaded. Please ensure fzf-lua is correctly installed and updated.")
   end
 
   return M
 end
-
-local rg_options = {
-  '--no-messages',
-  '--no-heading',    -- Don't print the initial summary
-  '--with-filename', -- Print the filename for each match
-  '--follow',        -- Follow symbolic links
-  '--smart-case',    -- Search case-insensitively unless query contains uppercase
-  '--line-number',   -- Print the line number for each match
-  '--color=never',   -- Disable ripgrep's colors; fzf will handle colors
-}
 
 local fzf_options = {
   ['--ansi'] = '',  -- Interpret ANSI color codes (though rg --color=never should prevent them)
@@ -34,7 +24,7 @@ local function key_handler(selected, note_key)
   vim.call("ZK_note_handler", { query, note_key, table_unpack(selected) })
 end
 
-function M.search_notes(_, create_note_key, yank_key)
+function M.search_notes(_, create_note_key, yank_key, rg_options)
   fzf_lua.live_grep({
     prompt = 'Search> ',
     grep_cmd = "rg",

--- a/plugin/zappykasten.vim
+++ b/plugin/zappykasten.vim
@@ -371,8 +371,10 @@ endfunction
 " Command to start fuzzy search {{{1
 if s:use_fzf_lua
     silent! command -nargs=* -bang ZK lua require('zappykasten.fzf-lua')
-        \.search_notes(vim.fn.eval("s:main_dir"), vim.fn.eval("s:create_note_key"),
-        \   vim.fn.eval("s:yank_key"))
+        \.search_notes(vim.fn.eval("s:main_dir"),
+        \   vim.fn.eval("s:create_note_key"),
+        \   vim.fn.eval("s:yank_key"),
+        \   vim.fn.eval("s:rg_musts + s:rg_options"))
 else
     silent! command -nargs=* -bang ZK
           \ call fzf#run(

--- a/plugin/zappykasten.vim
+++ b/plugin/zappykasten.vim
@@ -16,8 +16,6 @@ if exists(':FZF') != 2
     else
         let s:use_fzf_lua = 1
     endif
-else
-    let s:use_fzf_vim = 1
 endif
 
 let s:ext = get(g:, 'zk_default_extension', '.md')
@@ -370,7 +368,9 @@ endfunction
 
 " Command to start fuzzy search {{{1
 if s:use_fzf_lua
-    silent! command -nargs=* -bang ZK lua require('zappykasten.fzf-lua').search_notes()
+    silent! command -nargs=* -bang ZK lua require('zappykasten.fzf-lua')
+        \.search_notes(vim.fn.eval("s:main_dir"), vim.fn.eval("s:create_note_key"),
+        \   vim.fn.eval("s:yank_key"))
 else
     silent! command -nargs=* -bang ZK
           \ call fzf#run(

--- a/plugin/zappykasten.vim
+++ b/plugin/zappykasten.vim
@@ -8,6 +8,8 @@ if !executable('rg')
 endif
 
 " Ensure the Vim plug-in `Fzf` is installed
+let s:use_fzf_lua = 0
+
 if exists(':FZF') != 2
     if exists(':FzfLua') != 2
         echomsg 'The Vim plug-in `Fzf` is not installed. See https://github.com/junegunn/fzf for installation instructions.'


### PR DESCRIPTION
Add basic support for fzf-lua.

Lua has it's own file and should not conflict with Vim.

What's implemented:
1) Searching
2) Few key bindings - creating and yanking the current result.

TODO:
1) Use more options from zappykasten side.
2) Notes linking (I don't use this feature, need to figure it out first).

fzf-lua has it's own ways for the many configuration parts (for example previews), probably these parts can be skipped from adding.